### PR TITLE
Add security utilities and global config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,59 @@
+# ================================
+# INTEGREAPP - ENVIRONMENT CONFIG
+# ================================
+
+# Application
+NEXT_PUBLIC_APP_NAME="IntegreApp"
+NEXT_PUBLIC_APP_VERSION="1.0.0"
+NEXT_PUBLIC_APP_URL="https://app.integreapp.com"
+NEXT_PUBLIC_AUTH_URL="https://auth.integreapp.com"
+NODE_ENV="development"
+
+# API Configuration
+NEXT_PUBLIC_API_BASE_URL="https://api.integreapp.com/v1"
+NEXT_PUBLIC_API_TIMEOUT="30000"
+API_SECRET_KEY="your-secret-key-here"
+
+# Authentication
+NEXTAUTH_URL="https://auth.integreapp.com"
+NEXTAUTH_SECRET="your-nextauth-secret-here"
+JWT_SECRET="your-jwt-secret-here"
+JWT_EXPIRES_IN="24h"
+REFRESH_TOKEN_EXPIRES_IN="7d"
+
+# OAuth Providers
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
+MICROSOFT_CLIENT_ID="your-microsoft-client-id"
+MICROSOFT_CLIENT_SECRET="your-microsoft-client-secret"
+
+# Security
+NEXT_PUBLIC_ALLOWED_DOMAINS="integreapp.com,localhost,127.0.0.1"
+ENCRYPTION_KEY="your-encryption-key-here"
+RATE_LIMIT_MAX="100"
+RATE_LIMIT_WINDOW="900000"
+
+# WebSocket
+NEXT_PUBLIC_WS_URL="wss://ws.integreapp.com"
+WS_SECRET="your-websocket-secret"
+
+# File Upload
+NEXT_PUBLIC_MAX_FILE_SIZE="10485760"
+NEXT_PUBLIC_ALLOWED_FILE_TYPES="image/jpeg,image/png,image/gif,application/pdf"
+
+# Monitoring & Analytics
+SENTRY_DSN="your-sentry-dsn"
+GOOGLE_ANALYTICS_ID="your-ga-id"
+
+# Feature Flags
+NEXT_PUBLIC_ENABLE_ANALYTICS="true"
+NEXT_PUBLIC_ENABLE_NOTIFICATIONS="true"
+NEXT_PUBLIC_ENABLE_WEBSOCKET="true"
+
+# Cache
+CACHE_TTL="300000"
+CACHE_MAX_SIZE="1000"
+
+# Development
+NEXT_PUBLIC_DEBUG="false"
+NEXT_PUBLIC_MOCK_API="false"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { ThemeProvider } from "@/providers/theme-provider";
+import { AppProvider } from "@/providers";
 import "@/styles/globals.css";
 import "@/styles/theme.css";
 
@@ -12,13 +12,7 @@ export default function AuthLayout({
 }>) {
   return (
     <section className="min-h-screen">
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="light"
-        disableTransitionOnChange
-      >
-        {children}
-      </ThemeProvider>
+      <AppProvider defaultTheme="light">{children}</AppProvider>
     </section>
   );
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "next-themes";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DashboardSidebar } from "@/theme";
 import { Icon } from "@/components/ui/custom/Icons";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -64,13 +65,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   }
 
   return (
-    <div className={`flex h-screen ${theme === "dark" ? "dark" : ""}`}>
-      {/* Sidebar principal do dashboard */}
-      <DashboardSidebar
-        isMobileMenuOpen={isMobileMenuOpen}
-        setIsMobileMenuOpen={setIsMobileMenuOpen}
-        isCollapsed={isCollapsed}
-      />
+    <ErrorBoundary>
+      <div className={`flex h-screen ${theme === "dark" ? "dark" : ""}`}>
+        {/* Sidebar principal do dashboard */}
+        <DashboardSidebar
+          isMobileMenuOpen={isMobileMenuOpen}
+          setIsMobileMenuOpen={setIsMobileMenuOpen}
+          isCollapsed={isCollapsed}
+        />
 
       {/* Container principal de conteúdo */}
       <div className="w-full flex flex-1 flex-col transition-all duration-300 ease-in-out bg-[var(--sidebar-primary)]">
@@ -111,5 +113,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         </main>
       </div>
     </div>
+    </ErrorBoundary>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,23 @@
 import type { Metadata } from "next";
-import { ThemeProvider } from "@/providers/theme-provider";
-import { ToasterCustom } from "@/components/ui/custom/toast"; // Substituir importação
+import { AppProvider } from "@/providers";
+import { SecurityHeaders } from "@/components/security/SecurityHeaders";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import { siteConfig } from "@/config/site";
+import { generateCSP } from "@/lib/security/csp";
+import { fonts } from "@/lib/fonts";
 import "@/styles/globals.css";
 import "@/styles/theme.css";
 
 export const metadata: Metadata = {
-  title: "IntegreApp - Plataforma de Gestão Integrada",
-  description: "Solução completa para gestão empresarial e social",
+  title: siteConfig.name,
+  description: siteConfig.description,
   viewport: "width=device-width, initial-scale=1",
+  keywords: siteConfig.keywords,
+  authors: siteConfig.authors,
+  creator: siteConfig.creator,
+  openGraph: siteConfig.openGraph,
+  twitter: siteConfig.twitter,
+  robots: siteConfig.robots,
 };
 
 /**
@@ -22,30 +32,21 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
+    <html
+      lang="pt-BR"
+      suppressHydrationWarning
+      className={`${fonts.sans.variable} ${fonts.mono.variable}`}
+    >
       <head>
-        {/* Meta tags e outros elementos de cabeçalho são gerenciados pelo Next.js */}
+        <meta httpEquiv="Content-Security-Policy" content={generateCSP()} />
       </head>
       <body className="min-h-screen font-sans antialiased">
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <main className="flex-1 flex flex-col">{children}</main>
-
-          {/* Container centralizado de notificações do sistema */}
-          <ToasterCustom
-            position="top-right"
-            theme="system"
-            richColors={true}
-            closeButton={false}
-            maxToasts={5}
-            gap={8}
-            defaultDuration={5000}
-          />
-        </ThemeProvider>
+        <SecurityHeaders />
+        <ErrorBoundary>
+          <AppProvider>
+            <main className="flex-1 flex flex-col">{children}</main>
+          </AppProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+  errorInfo?: ErrorInfo;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ errorInfo });
+    console.error("ErrorBoundary capturou um erro:", error, errorInfo);
+    if (process.env.NODE_ENV === "production") {
+      // Implementar envio para serviço de monitoramento
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex h-screen flex-col items-center justify-center p-4">
+          <div className="text-center">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              Oops! Algo deu errado
+            </h2>
+            <p className="text-gray-600 mb-6">
+              Ocorreu um erro inesperado. Nossa equipe foi notificada.
+            </p>
+            <div className="space-x-4">
+              <Button onClick={() => window.location.reload()} variant="default">
+                Recarregar página
+              </Button>
+              <Button onClick={() => window.history.back()} variant="outline">
+                Voltar
+              </Button>
+            </div>
+
+            {process.env.NODE_ENV === "development" && (
+              <details className="mt-6 text-left">
+                <summary className="cursor-pointer font-medium">
+                  Detalhes do erro (desenvolvimento)
+                </summary>
+                <pre className="mt-2 p-4 bg-gray-100 rounded text-sm overflow-auto">
+                  {this.state.error?.stack}
+                </pre>
+              </details>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/security/SecurityHeaders.tsx
+++ b/src/components/security/SecurityHeaders.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function SecurityHeaders() {
+  useEffect(() => {
+    const metaTags = [
+      { name: "referrer", content: "strict-origin-when-cross-origin" },
+      { "http-equiv": "X-Content-Type-Options", content: "nosniff" },
+      { "http-equiv": "X-Frame-Options", content: "DENY" },
+      { "http-equiv": "X-XSS-Protection", content: "1; mode=block" },
+      { name: "format-detection", content: "telephone=no" },
+    ];
+
+    metaTags.forEach(({ name, "http-equiv": httpEquiv, content }) => {
+      const meta = document.createElement("meta");
+      if (name) meta.name = name;
+      if (httpEquiv) meta.httpEquiv = httpEquiv;
+      meta.content = content;
+      document.head.appendChild(meta);
+    });
+
+    const preventDrop = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    document.addEventListener("dragover", preventDrop);
+    document.addEventListener("drop", preventDrop);
+
+    return () => {
+      document.removeEventListener("dragover", preventDrop);
+      document.removeEventListener("drop", preventDrop);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -1,0 +1,42 @@
+export const authConfig = {
+  allowedDomains: [
+    "auth.integreapp.com",
+    "localhost",
+    "127.0.0.1",
+    ...(process.env.NEXT_PUBLIC_ALLOWED_DOMAINS?.split(",") || []),
+  ],
+  rateLimit: {
+    maxAttempts: 5,
+    windowMs: 15 * 60 * 1000,
+    blockDuration: 60 * 60 * 1000,
+  },
+  session: {
+    maxAge: 24 * 60 * 60,
+    refreshThreshold: 15 * 60,
+    inactivityTimeout: 30 * 60 * 1000,
+  },
+  tokens: {
+    accessTokenExpiry: "15m",
+    refreshTokenExpiry: "7d",
+    emailVerificationExpiry: "24h",
+    passwordResetExpiry: "1h",
+  },
+  password: {
+    minLength: 8,
+    requireUppercase: true,
+    requireLowercase: true,
+    requireNumbers: true,
+    requireSpecialChars: true,
+    maxAttempts: 3,
+  },
+  oauth: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      scopes: ["openid", "email", "profile"],
+    },
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID,
+      scopes: ["openid", "email", "profile"],
+    },
+  },
+} as const;

--- a/src/config/dashboard.ts
+++ b/src/config/dashboard.ts
@@ -1,0 +1,32 @@
+export const dashboardConfig = {
+  inactivityTimeout: 30 * 60 * 1000,
+  sessionRefreshThreshold: 5 * 60 * 1000,
+  sessionWarningThreshold: 2 * 60 * 1000,
+  routePermissions: {
+    "/dashboard": ["dashboard:read"],
+    "/dashboard/overview": ["dashboard:read", "overview:read"],
+    "/dashboard/users": ["dashboard:read", "users:read"],
+    "/dashboard/users/create": ["dashboard:read", "users:create"],
+    "/dashboard/users/edit": ["dashboard:read", "users:update"],
+    "/dashboard/settings": ["dashboard:read", "settings:read"],
+    "/dashboard/settings/security": ["dashboard:read", "settings:security"],
+    "/dashboard/analytics": ["dashboard:read", "analytics:read"],
+    "/dashboard/reports": ["dashboard:read", "reports:read"],
+  } as Record<string, string[]>,
+  websocket: {
+    url: process.env.NEXT_PUBLIC_WS_URL || "wss://ws.integreapp.com",
+    reconnectAttempts: 5,
+    reconnectDelay: 3000,
+    heartbeatInterval: 30000,
+  },
+  cache: {
+    defaultTTL: 5 * 60 * 1000,
+    longTTL: 60 * 60 * 1000,
+    shortTTL: 30 * 1000,
+  },
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    allowedPageSizes: [10, 25, 50, 100],
+  },
+} as const;

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,38 @@
+export const siteConfig = {
+  name: "IntegreApp",
+  description: "Solução completa para gestão empresarial e social",
+  url: process.env.NEXT_PUBLIC_APP_URL || "https://app.integreapp.com",
+  keywords: ["gestão", "social", "empresarial", "integração"],
+  authors: [
+    {
+      name: "IntegreApp Team",
+      url: "https://integreapp.com",
+    },
+  ],
+  creator: "IntegreApp",
+  openGraph: {
+    type: "website",
+    locale: "pt_BR",
+    url: process.env.NEXT_PUBLIC_APP_URL,
+    title: "IntegreApp",
+    description: "Solução completa para gestão empresarial e social",
+    siteName: "IntegreApp",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "IntegreApp",
+    description: "Solução completa para gestão empresarial e social",
+    creator: "@integreapp",
+  },
+  robots: {
+    index: process.env.NODE_ENV === "production",
+    follow: process.env.NODE_ENV === "production",
+    googleBot: {
+      index: process.env.NODE_ENV === "production",
+      follow: process.env.NODE_ENV === "production",
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+} as const;

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,0 +1,14 @@
+import { Inter, JetBrains_Mono } from "next/font/google";
+
+export const fonts = {
+  sans: Inter({
+    subsets: ["latin"],
+    variable: "--font-sans",
+    display: "swap",
+  }),
+  mono: JetBrains_Mono({
+    subsets: ["latin"],
+    variable: "--font-mono",
+    display: "swap",
+  }),
+};

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,0 +1,38 @@
+export function generateCSP(): string {
+  const isDev = process.env.NODE_ENV === "development";
+
+  const policies: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      ...(isDev ? ["'unsafe-eval'", "'unsafe-inline'"] : []),
+      "https://cdn.jsdelivr.net",
+      "https://unpkg.com",
+    ],
+    "style-src": [
+      "'self'",
+      "'unsafe-inline'",
+      "https://fonts.googleapis.com",
+    ],
+    "img-src": ["'self'", "data:", "blob:", "https:"],
+    "font-src": ["'self'", "https://fonts.gstatic.com"],
+    "connect-src": [
+      "'self'",
+      "https://api.integreapp.com",
+      "wss://ws.integreapp.com",
+      ...(isDev ? ["ws://localhost:", "http://localhost:"] : []),
+    ],
+    "media-src": ["'self'"],
+    "object-src": ["'none'"],
+    "child-src": ["'none'"],
+    "frame-ancestors": ["'none'"],
+    "form-action": ["'self'"],
+    "base-uri": ["'self'"],
+    "manifest-src": ["'self'"],
+    "worker-src": ["'self'", "blob:"],
+  };
+
+  return Object.entries(policies)
+    .map(([directive, sources]) => `${directive} ${sources.join(" ")}`)
+    .join("; ");
+}

--- a/src/providers/app-provider.tsx
+++ b/src/providers/app-provider.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+import { ThemeProvider } from "./theme-provider";
+import { ToasterCustom } from "@/components/ui/custom/toast";
+
+interface Props {
+  children: ReactNode;
+  defaultTheme?: string;
+}
+
+export function AppProvider({ children, defaultTheme = "system" }: Props) {
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme={defaultTheme}
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+      <ToasterCustom
+        position="top-right"
+        theme="system"
+        richColors={true}
+        closeButton={false}
+        maxToasts={5}
+        gap={8}
+        defaultDuration={5000}
+      />
+    </ThemeProvider>
+  );
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,2 @@
+export { ThemeProvider } from "./theme-provider";
+export { AppProvider } from "./app-provider";


### PR DESCRIPTION
## Summary
- add site, auth and dashboard config modules
- include global fonts and CSP generator
- add ErrorBoundary and SecurityHeaders components
- introduce AppProvider with ThemeProvider and Toast
- enhance root, auth and dashboard layouts
- provide `.env.example` and allow tracked env example

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff53f5488325ac4e85d2f860f749