### PR TITLE
Implement basic auth provider and route guards

### DIFF
--- a/src/app/dashboard/middleware.ts
+++ b/src/app/dashboard/middleware.ts
@@ -25,6 +25,14 @@ export function dashboardMiddleware(request: NextRequest) {
 
   if (!isAppSubdomain) return NextResponse.next();
 
+  // Verifica a presença do JWT
+  if (!request.cookies.get("access_token")) {
+    const redirectUrl = new URL(request.url);
+    redirectUrl.hostname = redirectUrl.hostname.replace(/^app\./, "auth.");
+    redirectUrl.pathname = "/auth/login";
+    return NextResponse.redirect(redirectUrl);
+  }
+
   // Se estamos na raiz do app, redirecionar para analytics
   if (pathname === "/") {
     return NextResponse.rewrite(new URL("/dashboard/overview", request.url));

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/providers/auth-provider";
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  roles?: string[];
+  permissions?: string[];
+}
+
+export function ProtectedRoute({ children, roles = [], permissions = [] }: ProtectedRouteProps) {
+  const { user, permissions: userPermissions, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading) {
+      if (!user) {
+        router.replace("/auth/login");
+        return;
+      }
+      if (roles.length && user && !roles.includes(user.role)) {
+        router.replace("/dashboard/unauthorized");
+        return;
+      }
+      if (permissions.some((p) => !userPermissions.includes(p))) {
+        router.replace("/dashboard/unauthorized");
+      }
+    }
+  }, [loading, user, userPermissions, router, roles, permissions]);
+
+  if (loading || !user) return null;
+  if (roles.length && user && !roles.includes(user.role)) return null;
+  if (permissions.some((p) => !userPermissions.includes(p))) return null;
+
+  return <>{children}</>;
+}

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,2 @@
+export { ProtectedRoute } from "./ProtectedRoute";
+export { withAuth } from "./withAuth";

--- a/src/components/auth/withAuth.tsx
+++ b/src/components/auth/withAuth.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ProtectedRoute } from "./ProtectedRoute";
+
+interface Options {
+  roles?: string[];
+  permissions?: string[];
+}
+
+export function withAuth<P>(Component: React.ComponentType<P>, options?: Options) {
+  return function AuthenticatedComponent(props: P) {
+    return (
+      <ProtectedRoute roles={options?.roles} permissions={options?.permissions}>
+        <Component {...props} />
+      </ProtectedRoute>
+    );
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -54,6 +54,15 @@ export function middleware(request: NextRequest) {
 
   // === SUBDOMÍNIO APP ===
   if (isAppSubdomain) {
+    // Verifica a presença do JWT
+    const hasJwt = request.cookies.get("access_token");
+    if (!hasJwt) {
+      const redirectUrl = new URL(request.url);
+      redirectUrl.hostname = redirectUrl.hostname.replace(/^app\./, "auth.");
+      redirectUrl.pathname = "/auth/login";
+      return NextResponse.redirect(redirectUrl);
+    }
+
     // Raiz do app -> dashboard/overview
     if (pathname === "/") {
       const rewriteResponse = NextResponse.rewrite(

--- a/src/providers/app-provider.tsx
+++ b/src/providers/app-provider.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { ThemeProvider } from "./theme-provider";
+import { AuthProvider } from "./auth-provider";
 import { ToasterCustom } from "@/components/ui/custom/toast";
 
 interface Props {
@@ -15,16 +16,18 @@ export function AppProvider({ children, defaultTheme = "system" }: Props) {
       enableSystem
       disableTransitionOnChange
     >
-      {children}
-      <ToasterCustom
-        position="top-right"
-        theme="system"
-        richColors={true}
-        closeButton={false}
-        maxToasts={5}
-        gap={8}
-        defaultDuration={5000}
-      />
+      <AuthProvider>
+        {children}
+        <ToasterCustom
+          position="top-right"
+          theme="system"
+          richColors={true}
+          closeButton={false}
+          maxToasts={5}
+          gap={8}
+          defaultDuration={5000}
+        />
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+interface User {
+  id: string;
+  name: string;
+  role: string;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  permissions: string[];
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  permissions: [],
+  loading: true,
+  refresh: async () => {},
+});
+
+async function fetchSessionData() {
+  try {
+    const res = await fetch("/api/auth/session", {
+      credentials: "include",
+    });
+    if (!res.ok) throw new Error("Unauthenticated");
+    return (await res.json()) as { user: User | null; permissions: string[] };
+  } catch {
+    return { user: null, permissions: [] };
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [permissions, setPermissions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadSession = async () => {
+    setLoading(true);
+    const data = await fetchSessionData();
+    setUser(data.user);
+    setPermissions(data.permissions);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadSession();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, permissions, loading, refresh: loadSession }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,2 +1,3 @@
 export { ThemeProvider } from "./theme-provider";
 export { AppProvider } from "./app-provider";
+export { AuthProvider, useAuth } from "./auth-provider";


### PR DESCRIPTION
## Summary
- add `AuthProvider` to manage session state
- expose auth context in AppProvider
- create `ProtectedRoute` and `withAuth` wrappers for pages
- enforce token presence in middleware

## Testing
- `npm install` *(fails: dependency conflicts)*
- `npm run lint` *(fails: next not found due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68420383285c832591f00b6958b90d70