### PR TITLE
Add tenant header API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Tenant-aware API Requests
+
+Outgoing requests made with the custom `apiClient` automatically include the tenant identifier.
+The value is read from the `tenant_selection` cookie using `nookies` and attached as the `X-Tenant-ID` header if present.

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,13 @@
+import { parseCookies } from 'nookies'
+
+export async function apiClient(url: string, options: RequestInit = {}) {
+  const cookies = parseCookies()
+  const tenantId = cookies['tenant_selection']
+
+  const headers = new Headers(options.headers)
+  if (tenantId) {
+    headers.set('X-Tenant-ID', tenantId)
+  }
+
+  return fetch(url, { ...options, headers })
+}


### PR DESCRIPTION
## Summary
- add a simple API client wrapper that reads `tenant_selection` cookie and sets `X-Tenant-ID`
- document tenant header behavior in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842038404b48325b6d9c7563822b438