### PR TITLE
Fix font loader usage

### DIFF
--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,14 +1,27 @@
 import { Inter, JetBrains_Mono } from "next/font/google";
 
+/**
+ * Os carregadores de fontes do Next.js devem ser executados
+ * diretamente no escopo do módulo. Caso contrário o build lança
+ * um erro informando que o loader precisa ser atribuído a uma
+ * constante. Para seguir essa regra, criamos duas constantes
+ * (`inter` e `jetBrainsMono`) e as exportamos através do objeto
+ * `fonts`.
+ */
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  display: "swap",
+});
+
 export const fonts = {
-  sans: Inter({
-    subsets: ["latin"],
-    variable: "--font-sans",
-    display: "swap",
-  }),
-  mono: JetBrains_Mono({
-    subsets: ["latin"],
-    variable: "--font-mono",
-    display: "swap",
-  }),
+  sans: inter,
+  mono: jetBrainsMono,
 };


### PR DESCRIPTION
## Summary
- load fonts via constants in module scope

## Testing
- `npm run lint` *(fails: Image is defined but never used)*
- `npm run build` *(fails to compile due to lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842401fd9188325b8b1852766517b76